### PR TITLE
MOB-38674 Upgrade okhttp client to 3.10.0 to address issues with HTTP connections not properly being closed and starving connection pool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.6.0</version>
+            <version>3.10.0</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>logging-interceptor</artifactId>
-            <version>3.6.0</version>
+            <version>3.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/test/java/com/blazemeter/api/http/RetryInterceptorTest.java
+++ b/src/test/java/com/blazemeter/api/http/RetryInterceptorTest.java
@@ -14,10 +14,15 @@
 
 package com.blazemeter.api.http;
 
+import com.blazemeter.api.http.RetryInterceptorTest.ChainImpl;
+import com.blazemeter.api.http.RetryInterceptorTest.ChainWithErrorImpl;
 import com.blazemeter.api.logging.LoggerTest;
 import com.blazemeter.api.utils.BlazeMeterUtilsEmul;
+
+import okhttp3.Call;
 import okhttp3.Connection;
 import okhttp3.Interceptor;
+import okhttp3.Interceptor.Chain;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -26,6 +31,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeUnit;
 
 import static com.blazemeter.api.http.HttpUtils.JSON_CONTENT;
 import static org.junit.Assert.assertEquals;
@@ -72,8 +78,43 @@ public class RetryInterceptorTest {
         }
 
         @Override
+        public Call call() {
+            return null;
+        }
+        
+        @Override
         public Connection connection() {
             return null;
+        }
+
+        @Override
+        public int connectTimeoutMillis() {
+            return 0;
+        }
+
+        @Override
+        public Chain withConnectTimeout(int timeout, TimeUnit unit) {
+            return this;
+        }
+
+        @Override
+        public int readTimeoutMillis() {
+            return 0;
+        }
+
+        @Override
+        public Chain withReadTimeout(int timeout, TimeUnit unit) {
+            return this;
+        }
+
+        @Override
+        public int writeTimeoutMillis() {
+            return 0;
+        }
+
+        @Override
+        public Chain withWriteTimeout(int timeout, TimeUnit unit) {
+            return this;
         }
     }
 
@@ -124,8 +165,43 @@ public class RetryInterceptorTest {
         }
 
         @Override
+        public Call call() {
+            return null;
+        }
+
+        @Override
         public Connection connection() {
             return null;
+        }
+
+        @Override
+        public int connectTimeoutMillis() {
+            return 0;
+        }
+
+        @Override
+        public Chain withConnectTimeout(int timeout, TimeUnit unit) {
+            return this;
+        }
+
+        @Override
+        public int readTimeoutMillis() {
+            return 0;
+        }
+
+        @Override
+        public Chain withReadTimeout(int timeout, TimeUnit unit) {
+            return this;
+        }
+
+        @Override
+        public int writeTimeoutMillis() {
+            return 0;
+        }
+
+        @Override
+        public Chain withWriteTimeout(int timeout, TimeUnit unit) {
+            return this;
         }
     }
 


### PR DESCRIPTION
https://perforce.atlassian.net/browse/MOB-38674

When using version 3.6.0 of the OkHttp client, occasionally an HTTP request will hang when waiting for a response.  This can happen after an hour of usage, as is the case for the Blazemeter Jenkins Plugin when polling a long running test.

This was fixed in version 3.9.0 of OkHttp - https://github.com/square/okhttp/issues/3422